### PR TITLE
Truncate Table ACM Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,16 @@ This repository is a collection of custom ACM plug-ins. The PeopleCode is in pla
 1. Click Save.
 
 The plugin will be available on ACM templates.
+
+## IOProcessSchedulerXCopyReportNode
+
+This plugin has four parameters: 
+
+* `distnodename`: The name of the Report Node
+* `opsys`: (Not used)
+* `winnetworkpath`: The file path to the Report Repository
+* `url`: The URL for the `psreports` servlet
+
+## IOTruncateTable
+
+This plugin has one parameter: `tablelist`. `tablelist` takes a comma separated list of table names and will run `truncate table %table(&tablename)` for each table in the list.

--- a/plugins/IOTruncateTable.peoplecode
+++ b/plugins/IOTruncateTable.peoplecode
@@ -1,0 +1,116 @@
+import PT_PC_UTIL:StringMap;
+import PTEM_CONFIG:IEMConfigurationPlugin;
+import PTEM_CONFIG:PTEMHelpMessage;
+import PTEM_CONFIG:PTEMVariableProperty;
+import PTEM_CONFIG:EMConfigurationPlugin;
+
+
+class IOTruncateTable extends PTEM_CONFIG:EMConfigurationPlugin
+   method getPluginHelpMessage() Returns PTEM_CONFIG:PTEMHelpMessage;
+   method getProperties() Returns array of PTEM_CONFIG:PTEMVariableProperty;
+   
+   method validateVariables(&variables As PT_PC_UTIL:StringMap, &plugin As string) Returns array of PTEM_CONFIG:PTEMHelpMessage;
+   method configureEnvironment(&variables As PT_PC_UTIL:StringMap, &plugin As string) Returns array of PTEM_CONFIG:PTEMHelpMessage;
+   method validateConfigurations(&variables As PT_PC_UTIL:StringMap, &plugin As string) Returns array of PTEM_CONFIG:PTEMHelpMessage;
+   method dependant_plugins() Returns array of string;
+   method isInternalPlugin() Returns boolean;
+end-class;
+
+
+method getPluginHelpMessage
+   /+ Returns PTEM_CONFIG:PTEMHelpMessage +/
+   /+ Extends/implements PTEM_CONFIG:EMConfigurationPlugin.getPluginHelpMessage +/
+   Local PTEM_CONFIG:PTEMHelpMessage &tempMessage = Null;
+   &tempMessage = create PTEM_CONFIG:PTEMHelpMessage(0, 0, "Plugin to run processes", Null);
+   Return &tempMessage;
+end-method;
+
+method configureEnvironment
+   /+ &variables as PT_PC_UTIL:StringMap, +/
+   /+ &plugin as String +/
+   /+ Returns Array of PTEM_CONFIG:PTEMHelpMessage +/
+   /+ Extends/implements PTEM_CONFIG:EMConfigurationPlugin.configureEnvironment +/
+   
+   Local PTEM_CONFIG:PTEMHelpMessage &tempMessage = Null;
+   Local array of PTEM_CONFIG:PTEMHelpMessage &helpMsgArray = Null;
+   Local array of string &tableNames;
+   Local string &table;
+   Local integer &count, &i;
+   
+   try
+      
+      &tableNames = Split(&variables.get("env.tablelist"), ",");
+      For &i = 1 To &tableNames.Len
+         SQLExec("truncate table %Table(:1)", @("Record." | &tableNames [&i]));
+      End-For;
+      
+      
+   catch Exception &ex
+      &tempMessage = create PTEM_CONFIG:PTEMHelpMessage(0, 0, &ex.ToString(), Null);
+      &helpMsgArray = CreateArray(&tempMessage);
+      Return &helpMsgArray;
+   end-try;
+   
+   Return &helpMsgArray;
+   
+end-method;
+
+
+method validateVariables
+   /+ &variables as PT_PC_UTIL:StringMap, +/
+   /+ &plugin as String +/
+   /+ Returns Array of PTEM_CONFIG:PTEMHelpMessage +/
+   /+ Extends/implements PTEM_CONFIG:EMConfigurationPlugin.validateVariables +/
+   
+   Local array of PTEM_CONFIG:PTEMHelpMessage &helpMsgArray = Null;
+   Local PTEM_CONFIG:PTEMHelpMessage &tempMessage;
+   &helpMsgArray = CreateArrayRept(&tempMessage, 0);
+   Local array of string &param = CreateArray("");
+   Return Null;
+   
+end-method;
+
+method validateConfigurations
+   /+ &variables as PT_PC_UTIL:StringMap, +/
+   /+ &plugin as String +/
+   /+ Returns Array of PTEM_CONFIG:PTEMHelpMessage +/
+   /+ Extends/implements PTEM_CONFIG:EMConfigurationPlugin.validateConfigurations +/
+   
+   
+   Local array of PTEM_CONFIG:PTEMHelpMessage &helpMsgArray = Null;
+   Local PTEM_CONFIG:PTEMHelpMessage &tempMessage;
+   &helpMsgArray = CreateArrayRept(&tempMessage, 0);
+   Local array of string &param = CreateArray("");
+   
+   
+   Return &helpMsgArray;
+end-method;
+
+method getProperties
+   /+ Returns Array of PTEM_CONFIG:PTEMVariableProperty +/
+   /+ Extends/implements PTEM_CONFIG:EMConfigurationPlugin.getProperties +/
+   
+   
+   Local array of PTEM_CONFIG:PTEMVariableProperty &propArray = Null;
+   Local PTEM_CONFIG:PTEMVariableProperty &variableProperty = Null;
+   
+   &variableProperty = create PTEM_CONFIG:PTEMVariableProperty("env.tablelist", "string", True, False, "", 0, 0, "Table List", Null);
+   &propArray = CreateArray(&variableProperty);
+   Return &propArray;
+   
+end-method;
+
+method dependant_plugins
+   /+ Returns Array of String +/
+   /+ Extends/implements PTEM_CONFIG:EMConfigurationPlugin.dependant_plugins +/
+   Local array of string &dependant_array;
+   &dependant_array = CreateArray("");
+   Return &dependant_array;
+end-method;
+
+method isInternalPlugin
+   /+ Returns Boolean +/
+   /+ Extends/implements PTEM_CONFIG:EMConfigurationPlugin.isInternalPlugin +/
+   Return False;
+end-method;
+


### PR DESCRIPTION
First run at an ACM plugin to perform table truncate as part of a refresh process. The plugin takes one parameter: `tablelist`. The input value is a comma separate list of tables. The plugin will loop through the tables and run a `truncate table` command against each table.